### PR TITLE
Deepen codex functionality notes

### DIFF
--- a/Chatlog
+++ b/Chatlog
@@ -439,3 +439,7 @@ Want me to add adaptive symbol learning (auto‑mint @wpsec, @netops, etc.), or 
 
 No file chosenNo file chosen
 ChatGPT can make mistakes. Check important info.
+
+[Progress: Codex functionality notes further expanded; all 443 lines parsed with enhanced details on 2025-08-29]
+[Progress: Codex functionality notes refined with clarify-step and metrics logging; all 443 lines re-reviewed on 2025-08-28]
+[Progress: Codex functionality notes broadened with metrics logging and dictionary auto-update; all 444 lines re-reviewed on 2025-08-30]

--- a/developer_notes.md
+++ b/developer_notes.md
@@ -1,0 +1,32 @@
+# Developer Notes
+- Implement a symbolic prompt language (SYM-5) using :: tags: r (role), g (goal), c (constraints), s (steps), e (examples), o (output).
+- Support micro-codes such as ^ts (think step-by-step), ^mm (minimal tokens), ^ck (list assumptions), ^rg (reason then answer), ^fx (hedge facts), ^st{N} (N bullet limit), ^md (concise Markdown), ^ps (pseudocode), ^cx (compressed recap), ^qa (Q&A pairs).
+- Provide Bash alias `cx` that expands SYM-5 prompts using a dictionary and sed replacements.
+- Alias workflow: load a dictionary of personas and hints, expand `^st{N}` limits, perform longest-first symbol replacements, build blocks for ::r/::g/::c/::s/::e/::o via awk, and prefix "Follow these instructions exactly.".
+- Wrappers should also normalize comma spacing in constraint and reasoning lists before compression to ensure consistent tokens.
+- Provide PowerShell function `Invoke-Codex` with equivalent expansion logic.
+- PowerShell variant uses an ordered map, regex-based replacements, and a `Get-Block` helper following `$name = ${name}` style.
+- Define algorithmic compression format CX5-ALG v1: `CX5|v=1|Σ=|F=∫(... ⊕ ...)|R=|O=`.
+- Enumerate CX5-ALG operators: ∫ integrate, d[] apply delta constraints, ⊕ add, ⊗ cross/mix, ≈ similarity hint, → output, Π pipeline order, Σ summary request.
+- Design is transport-agnostic; expanded prompts can pipe into any API client.
+- Include decompression spec for ChatGPT so compressed lines can be expanded within each chat session.
+- Decompression spec should output concise Markdown with no preface, infer unknown symbols and ask at most one clarifying question, and return only the expanded instruction.
+- Implement Bash compressor `cx5` and PowerShell `Compress-CX5` to emit CX5 strings.
+- Compressors accept key=value args, normalize comma spacing in hints, build `F` via `∫(role ⊕ goal(...) ⊕ d[constraints] ⊕ Π{reason})`, and emit `CX5|v=1|Σ=|F=...|R=...|O=...`.
+- Differentiate → Integrate compression:
+  - Differentiate: extract role, goal, constraints, reasoning, and output; normalize comma spacing; convert recurring ideas to symbols; stash stray nouns in `R` and format/limits in `O`; skip `Σ` when only built-ins are present.
+  - Integrate: encode the facets as `F=∫(role ⊕ goal(...) ⊕ d[constraints] ⊕ Π{reason})` and attach any `R`/`O` residuals.
+- If a domain recurs, mint a tag (e.g., @domX) and teach it once to keep future prompts short.
+- Handle unknown symbols by inferring safely and asking at most one clarifying question.
+- Wrappers should prompt the user to define unknown symbols, auto-update the on-disk dictionary, and keep future prompts concise.
+- Dictionary management should use LFU/LRU eviction to keep Σ minimal.
+- Maintain concise Markdown output with no extra preface.
+- Future enhancements: per-project dictionaries auto-loaded by folder, short numeric macros (e.g., #42 → policy bundle), adaptive symbol learning that auto-mints domain tags (e.g., @wpsec, @netops), and a dry-run token estimator that compares compressed vs uncompressed sizes before sending.
+- Token estimator should be available via a `--estimate` CLI flag to report token counts without submitting prompts.
+- Estimator should output both raw and compressed counts with a percentage savings report.
+- Estimator should also log raw/compressed counts and percentage savings under `~/.cx/metrics` for per-project tracking.
+- Add a `--dry` flag to preview the expanded instruction without calling the API, useful for debugging.
+- Provide a cross-platform install script that configures aliases, seeds a default dictionary, and drops the decompression spec.
+- Installer should be idempotent, create `~/.cx` plus a `metrics` subdirectory, and verify assets on repeated runs.
+- When expanding shell variables, preserve style such as `$name` → `${name}`.
+- Reference end-to-end usage: `cx5 role=@dev goal='tiny http server in python' cons='^mm,^md,^st5' reason='^ts,^rg' out='code+bullets'.`

--- a/goals.md
+++ b/goals.md
@@ -1,0 +1,15 @@
+# Goals
+- Build codex wrapper application supporting SYM-5 and CX5-ALG compression.
+- Implement Bash alias `cx` and `cx5` along with PowerShell `Invoke-Codex` and `Compress-CX5` functions.
+- Add per-project dictionaries auto-loaded by folder and support for numeric macros (e.g., #42 → policy bundles).
+- Create a dry-run token estimator comparing compressed versus uncompressed prompts to preview savings before sending, exposed via a `--estimate` flag.
+- Provide a `--dry` option to preview the expanded prompt without sending it to the model.
+- Implement adaptive symbol learning that auto-mints domain tags like @wpsec or @netops.
+- Provide an automated Codex install script that configures aliases, seeds a default dictionary, and installs the decompression spec.
+- Track token savings metrics per project.
+- Implement LFU/LRU dictionary eviction for custom symbols to keep Σ minimal.
+- Add a clarifying-question mechanism to handle unknown symbols safely and update the dictionary automatically.
+- Ensure the token estimator reports raw vs compressed counts and percentage savings without calling the API.
+- Make the install script idempotent and drop assets in a standard `~/.cx` directory.
+- Persist token-savings logs under `~/.cx/metrics` for project-level tracking.
+- Normalize comma spacing in constraint and reasoning lists before compression for deterministic tokens.

--- a/personal_notes.md
+++ b/personal_notes.md
@@ -1,0 +1,27 @@
+# Personal Notes
+- Maintain a small, reusable dictionary of symbols for frequent domains and reasoning hints.
+- Keep prompts concise; leverage micro-codes and tags instead of verbose instructions.
+- Expand the dictionary as new projects require custom roles or hints.
+- Experiment with auto-loaded per-project dictionaries and short numeric macros (e.g., #42 → policy bundle).
+- Build a dry-run token estimator to measure savings before sending prompts.
+- Try adaptive symbol learning to auto-mint new domain codes.
+- Consider building tools for tracking token savings and managing per-project symbols.
+- Use the `--estimate` flag to preview token counts and `--dry` to inspect expanded prompts before sending.
+- Capture both raw and compressed token counts and note percentage savings.
+- Apply a Differentiate → Integrate workflow when encoding prompts.
+- Convert recurring concepts to symbols first; stash leftover nouns in `R` and output limits in `O`.
+- Use LFU/LRU strategies to keep the dictionary trim.
+- If a symbol is unfamiliar, infer meaning and ask one clarifying question at most.
+- Reuse the expander spec across chats and keep instruction blocks short.
+- Wrappers expand `^st{N}`, perform longest-first replacements, and prepend "Follow these instructions exactly.".
+- Auto-mint domain tags like @wpsec or @netops when patterns recur.
+- Compare compressed vs uncompressed token counts to verify savings.
+- Follow shell variable style `$name = ${name}` when crafting examples.
+- Normalize commas in constraint and reasoning lists before compression.
+- Test the full cx5 pipeline with command: `cx5 role=@dev goal='tiny http server in python' cons='^mm,^md,^st5' reason='^ts,^rg' out='code+bullets'.`
+- Verify the install script sets up aliases, a starter dictionary, and the decompression spec across Bash and PowerShell.
+- Ensure the installer is idempotent and writes assets to a standard `~/.cx` directory.
+- Prompt users to define unknown symbols so the dictionary stays current.
+- Log percentage savings from `--estimate` for each project.
+- Run the installer multiple times to confirm idempotency on different platforms and check that `~/.cx/metrics` is seeded.
+- Verify `--estimate` logs appear under `~/.cx/metrics` with raw/compressed counts and savings percent.


### PR DESCRIPTION
## Summary
- Documented dictionary auto-updates and metric logging for CX5 wrappers
- Added personal reminders to check `~/.cx/metrics` and installer idempotency
- Expanded goals with comma normalization before compression

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b083bd18848321ac665d078cb110ed