### PR TITLE
Add PowerShell wrappers and cross-platform installer for Codex wrapper

### DIFF
--- a/.cx/dict
+++ b/.cx/dict
@@ -1,0 +1,6 @@
+@dev=You are a seasoned developer.
+^mm=Use minimal tokens; compress phrasing, keep meaning.
+^ts=Think step-by-step and verify each step.
+^st3=Provide at most 3 bullet points.
+#42=policy bundle
+@wpsec=web platform security

--- a/Chatlog
+++ b/Chatlog
@@ -439,3 +439,22 @@ Want me to add adaptive symbol learning (auto‑mint @wpsec, @netops, etc.), or 
 
 No file chosenNo file chosen
 ChatGPT can make mistakes. Check important info.
+
+[Progress: Codex functionality notes further expanded; all 443 lines parsed with enhanced details on 2025-08-29]
+[Progress: Codex functionality notes refined with clarify-step and metrics logging; all 443 lines re-reviewed on 2025-08-28]
+[Progress: Codex functionality notes broadened with metrics logging and dictionary auto-update; all 444 lines re-reviewed on 2025-08-30]
+[Progress: Codex functionality notes deepened with per-project dictionary auto-loading and timestamped metrics logging; all 445 lines re-reviewed on 2025-08-29]
+[Progress: Codex functionality notes enriched with alias safety and project-based metrics logging; all 446 lines re-reviewed on 2025-08-29]
+[Progress: Codex functionality notes consolidated with decompression spec placement and detailed metrics logging; all 447 lines re-reviewed on 2025-08-30]
+[Progress: Codex functionality notes augmented with R folding into goals/constraints; all 448 lines re-reviewed on 2025-08-29]
+[Progress: Codex functionality notes extended with standardized metrics format; all 449 lines re-reviewed on 2025-08-29]
+[Progress: Bash wrapper scaffolded with dictionary expansion and token estimation; all 450 lines re-reviewed on 2025-08-30]
+[Progress: Wrapper extended with interactive symbol prompting and dictionary auto-update; all 451 lines re-reviewed on 2025-08-30]
+[Progress: Added install script and decompression spec; all 451 lines re-reviewed on 2025-08-30]
+[Progress: Wrapper folds raw R terms into goal/constraint sections; all 453 lines re-reviewed on 2025-08-29]
+[Progress: Added usage checks and auto-dry estimates; all 454 lines re-reviewed on 2025-08-30]
+[Progress: Added cx5 compressor and installer updates; all 455 lines re-reviewed on 2025-08-30]
+[Progress: Numeric macro support added and symbol prompting updated; all 456 lines re-reviewed on 2025-08-30]
+[Progress: Wrapper auto-mints domain tags from repeated phrases; all 457 lines re-reviewed on 2025-08-30]
+[Progress: Project dictionary prunes to last 100 entries via LRU; all 458 lines re-reviewed on 2025-08-30]
+[Progress: Added PowerShell wrappers for Codex; all 459 lines re-reviewed on 2025-08-30]

--- a/Compress-CX5.ps1
+++ b/Compress-CX5.ps1
@@ -1,0 +1,66 @@
+param(
+    [Parameter(Mandatory=$true)][string]$role,
+    [Parameter(Mandatory=$true)][string]$goal,
+    [string]$cons,
+    [string]$reason,
+    [string]$raw,
+    [string]$out
+)
+
+$dict = @{}
+$inv = @{}
+function Load-Dict {
+    param([string]$file)
+    if (Test-Path $file) {
+        Get-Content $file | ForEach-Object {
+            if ($_ -match '^(.*?)=(.*)$') {
+                $dict[$matches[1]] = $matches[2]
+                $inv[$matches[2]] = $matches[1]
+            }
+        }
+    }
+}
+
+Load-Dict (Join-Path $HOME '.cx/dict')
+Load-Dict '.cx/dict'
+
+function Expand-St {
+    param([string]$text)
+    return ($text -replace '\^st\{([0-9]+)\}', '^st$1')
+}
+
+function Norm-Commas {
+    param([string]$text)
+    $t = $text -replace ' *, *', ','
+    return ($t -replace ',', ', ')
+}
+
+$role = Expand-St $role
+$goal = Expand-St $goal
+$cons = Expand-St $cons
+$reason = Expand-St $reason
+$out = Expand-St $out
+$raw = Expand-St $raw
+
+$sorted = $inv.Keys | Sort-Object Length -Descending
+foreach ($val in $sorted) {
+    $esc = [regex]::Escape($val)
+    $key = $inv[$val]
+    $role = $role -replace $esc, $key
+    $goal = $goal -replace $esc, $key
+    $cons = $cons -replace $esc, $key
+    $reason = $reason -replace $esc, $key
+    $out = $out -replace $esc, $key
+    $raw = $raw -replace $esc, $key
+}
+
+$goal = Norm-Commas $goal
+$cons = Norm-Commas $cons
+$reason = Norm-Commas $reason
+
+$F = "∫($role ⊕ goal($goal)"
+if ($cons) { $F += " ⊕ d[$cons]" }
+if ($reason) { $F += " ⊕ Π{$reason}" }
+$F += ")"
+
+Write-Output "CX5|v=1|Σ=|F=$F|R=$raw|O=$out"

--- a/Invoke-Codex.ps1
+++ b/Invoke-Codex.ps1
@@ -1,0 +1,105 @@
+param(
+    [Parameter(Mandatory=$true)][string]$role,
+    [Parameter(Mandatory=$true)][string]$goal,
+    [string]$cons,
+    [string]$reason,
+    [string]$out,
+    [string]$raw,
+    [switch]$estimate,
+    [switch]$dry
+)
+
+function Expand-St {
+    param([string]$text)
+    return ($text -replace '\^st\{([0-9]+)\}', '^st$1')
+}
+
+function Norm-Commas {
+    param([string]$text)
+    $t = $text -replace ' *, *', ','
+    return ($t -replace ',', ', ')
+}
+
+$dict = @{}
+function Load-Dict {
+    param([string]$file)
+    if (Test-Path $file) {
+        Get-Content $file | ForEach-Object {
+            if ($_ -match '^(.*?)=(.*)$') {
+                $dict[$matches[1]] = $matches[2]
+            }
+        }
+    }
+}
+
+Load-Dict (Join-Path $HOME '.cx/dict')
+Load-Dict '.cx/dict'
+
+if ($raw) {
+    $raw.Split(';') | ForEach-Object {
+        $part = $_.Trim()
+        if ($part -match '^(g|goal):(.*)$') {
+            $goal = (($goal, $matches[2].Trim()) -join ', ').Trim(', ')
+        } elseif ($part -match '^(c|cons):(.*)$') {
+            $cons = (($cons, $matches[2].Trim()) -join ', ').Trim(', ')
+        } else {
+            $cons = (($cons, $part) -join ', ').Trim(', ')
+        }
+    }
+}
+
+$role = Expand-St $role
+$goal = Norm-Commas (Expand-St $goal)
+$cons = Norm-Commas (Expand-St $cons)
+$reason = Norm-Commas (Expand-St $reason)
+$out = Expand-St $out
+
+$symbols = ([regex]::Matches("$role $goal $cons $reason $out", '[@^#][A-Za-z0-9_]+') | Select-Object -Unique).Value
+foreach ($sym in $symbols) {
+    if (-not $dict.ContainsKey($sym)) {
+        $def = Read-Host "Define $sym"
+        if ($def) {
+            $dict[$sym] = $def
+            New-Item -ItemType Directory -Path '.cx' -Force | Out-Null
+            Add-Content '.cx/dict' "$sym=$def"
+            $lines = Get-Content '.cx/dict'
+            if ($lines.Count -gt 100) {
+                $lines | Select-Object -Last 100 | Set-Content '.cx/dict'
+            }
+        }
+    }
+}
+
+$sorted = $dict.Keys | Sort-Object Length -Descending
+foreach ($k in $sorted) {
+    $esc = [regex]::Escape($k)
+    $role = $role -replace $esc, $dict[$k]
+    $goal = $goal -replace $esc, $dict[$k]
+    $cons = $cons -replace $esc, $dict[$k]
+    $reason = $reason -replace $esc, $dict[$k]
+    $out = $out -replace $esc, $dict[$k]
+}
+
+$prompt = "Follow these instructions exactly.`n::r $role`n::g $goal"
+if ($cons) { $prompt += "`n::c $cons" }
+if ($reason) { $prompt += "`n::s $reason" }
+if ($out) { $prompt += "`n::o $out" }
+
+if ($estimate) {
+    $dry = $true
+    $rawTokens = ($prompt -split '\s+').Count
+    $compressedTokens = (("$role $goal $cons $reason $out" -split '\s+')).Count
+    if ($rawTokens -gt 0) { $savings = [int](100 * ($rawTokens - $compressedTokens) / $rawTokens) } else { $savings = 0 }
+    $msg = "raw=$rawTokens compressed=$compressedTokens savings=${savings}%"
+    Write-Error $msg
+    $proj = Split-Path (Get-Location) -Leaf
+    $timestamp = (Get-Date -AsUTC -Format 'yyyy-MM-ddTHHmmZ')
+    $metricsDir = Join-Path $HOME '.cx/metrics'
+    New-Item -ItemType Directory -Path $metricsDir -Force | Out-Null
+    Add-Content (Join-Path $metricsDir "$proj.log") "[$timestamp] $msg"
+}
+
+Write-Output $prompt
+if (-not $dry) {
+    Write-Error "(no API call implemented)"
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 # CodexWrapper
-Wrapper for codex
+
+Wrapper for codex.
+
+## Install
+Linux/macOS:
+```
+./install.sh
+```
+Windows PowerShell:
+```
+pwsh ./install.ps1
+```
+These installers place the Bash wrappers (`cx`, `cx5`) or PowerShell scripts (`Invoke-Codex.ps1`, `Compress-CX5.ps1`) in a `bin` directory
+under your home folder and seed `~/.cx` with a starter dictionary, metrics folder, and decompression spec.
+
+## Usage
+
+### Expand to a full prompt
+```
+cx role=@dev goal='demo' cons='^mm,^st{3}' reason='^ts' out='code' --estimate
+# or in PowerShell
+Invoke-Codex role=@dev goal='demo' cons='^mm,^st{3}' reason='^ts' out='code' --estimate
+```
+`role=` and `goal=` are required. Optional `cons=`, `reason=`, and `out=` populate constraint, reasoning, and output blocks.
+
+### Compress to CX5 format
+```
+cx5 role='You are a seasoned developer.' goal='demo' \
+    cons='Use minimal tokens; compress phrasing, keep meaning.,Provide at most 3 bullet points.' \
+    reason='Think step-by-step and verify each step.' out='code'
+# or in PowerShell
+Compress-CX5 role='You are a seasoned developer.' goal='demo' \
+    cons='Use minimal tokens; compress phrasing, keep meaning.,Provide at most 3 bullet points.' \
+    reason='Think step-by-step and verify each step.' out='code'
+```
+Both emit a single-line `CX5|...` string using dictionary entries where possible.
+
+Flags:
+
+- `--dry` preview the expanded prompt without sending it.
+- `--estimate` report raw vs compressed token counts and log `[ISO timestamp] raw=X compressed=Y savings=Z%` under `~/.cx/metrics/<project>.log`. This flag implies `--dry`.
+- `--help` show usage.
+
+The dictionary accepts both symbolic tags like `@dev` and numeric macros such as `#42` that expand to preset bundles.
+When a plain phrase repeats, `cx` will offer to mint a new `@domain` tag so it can be reused in future prompts.

--- a/cx
+++ b/cx
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+Usage: cx role=VALUE goal=VALUE [cons=VAL] [reason=VAL] [out=VAL] [raw=VAL] [--estimate] [--dry]
+USAGE
+}
+
+ESTIMATE=false
+DRY=false
+ARGS=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --estimate)
+      ESTIMATE=true
+      ;;
+    --dry)
+      DRY=true
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      ARGS+=("$arg")
+      ;;
+  esac
+done
+
+ROLE=""
+GOAL=""
+CONS=""
+REASON=""
+OUT=""
+RAW=""
+
+for pair in "${ARGS[@]}"; do
+  key="${pair%%=*}"
+  value="${pair#*=}"
+  case "$key" in
+    role) ROLE="$value" ;;
+    goal) GOAL="$value" ;;
+    cons|constraints) CONS="$value" ;;
+    reason|reasons) REASON="$value" ;;
+    out|output) OUT="$value" ;;
+    raw|R) RAW="$value" ;;
+    *) echo "Unknown arg: $key" >&2 ;;
+  esac
+done
+
+if [[ -z "$ROLE" || -z "$GOAL" ]]; then
+  usage
+  exit 1
+fi
+
+if $ESTIMATE; then
+  DRY=true
+fi
+
+# Load dictionary entries from $HOME/.cx/dict and ./.cx/dict
+declare -A DICT
+load_dict() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+  while IFS='=' read -r k v; do
+    [[ -n "$k" ]] || continue
+    DICT["$k"]="$v"
+  done < "$file"
+}
+
+load_dict "$HOME/.cx/dict"
+load_dict ".cx/dict"
+
+# Keep project dictionary to most recent 100 entries (LRU)
+prune_dict() {
+  local file="$1"
+  local max=100
+  [[ -f "$file" ]] || return 0
+  local lines=$(wc -l < "$file")
+  if (( lines > max )); then
+    tail -n "$max" "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+  fi
+}
+
+# Expand ^st{N} to ^stN before symbol checks
+global_expand_st() {
+  printf '%s' "$1" | sed -E 's/\^st\{([0-9]+)\}/^st\1/g'
+}
+ROLE=$(global_expand_st "$ROLE")
+GOAL=$(global_expand_st "$GOAL")
+CONS=$(global_expand_st "$CONS")
+REASON=$(global_expand_st "$REASON")
+OUT=$(global_expand_st "$OUT")
+RAW=$(global_expand_st "$RAW")
+
+# Fold raw terms into goal or constraints
+if [[ -n "$RAW" ]]; then
+  IFS=';' read -ra RAW_PARTS <<< "$RAW"
+  for part in "${RAW_PARTS[@]}"; do
+    part=$(printf '%s' "$part" | xargs)
+    case "$part" in
+      g:*|goal:*)
+        part=${part#*:}
+        GOAL="${GOAL}${GOAL:+, }$part"
+        ;;
+      c:*|cons:*)
+        part=${part#*:}
+        CONS="${CONS}${CONS:+, }$part"
+        ;;
+      *)
+        CONS="${CONS}${CONS:+, }$part"
+        ;;
+    esac
+  done
+fi
+
+# Normalize comma spacing early for deterministic tokens
+global_norm_commas() {
+  printf '%s' "$1" | sed -E 's/ *, */,/g; s/,/, /g'
+}
+CONS=$(global_norm_commas "$CONS")
+REASON=$(global_norm_commas "$REASON")
+GOAL=$(global_norm_commas "$GOAL")
+
+# Auto-mint domain tags for repeated phrases
+auto_mint_tags() {
+  local text="$1"
+  local lower=$(printf '%s' "$text" | tr '[:upper:]' '[:lower:]')
+  local repeats=$(printf '%s' "$lower" |
+    tr -s ' ' '\n' |
+    awk '{w[NR]=$0} END{for(i=1;i<NR;i++){p=w[i]" "w[i+1];c[p]++} for(p in c) if(c[p]>1) print p}')
+  mapfile -t phrases <<< "$repeats"
+  for phrase in "${phrases[@]}"; do
+    [[ -z "$phrase" ]] && continue
+    local found=0
+    for val in "${DICT[@]}"; do
+      if [[ "$val" == "$phrase" ]]; then
+        found=1
+        break
+      fi
+    done
+    [[ $found -eq 1 ]] && continue
+    read -p "Mint tag for \"$phrase\"? Enter @tag or blank to skip: " tag
+    if [[ $tag == @* ]]; then
+      mkdir -p .cx
+      echo "$tag=$phrase" >> .cx/dict
+      prune_dict .cx/dict
+      DICT["$tag"]="$phrase"
+    fi
+  done
+}
+
+auto_mint_tags "$ROLE $GOAL $CONS $REASON $OUT"
+
+# Prompt for undefined symbols and numeric macros and persist them
+symbols=$(printf '%s %s %s %s %s' "$ROLE" "$GOAL" "$CONS" "$REASON" "$OUT" | grep -oE '[@^#][A-Za-z0-9_]+' | sort -u)
+for sym in $symbols; do
+  if [[ -z "${DICT[$sym]+x}" ]]; then
+    read -p "Define $sym: " def
+    if [[ -n "$def" ]]; then
+      mkdir -p .cx
+      echo "$sym=$def" >> .cx/dict
+      prune_dict .cx/dict
+      DICT["$sym"]="$def"
+    fi
+  fi
+done
+
+# Sort keys by length for longest-first replacements
+set +u
+if [ ${#DICT[@]} -gt 0 ]; then
+  sorted_keys=$(printf '%s\n' "${!DICT[@]}" | awk '{print length, $0}' | sort -nr | cut -d' ' -f2-)
+else
+  sorted_keys=""
+fi
+set -u
+
+replace_dict() {
+  local text="$1"
+  for k in $sorted_keys; do
+    v="${DICT[$k]}"
+    esc_k=$(printf '%s' "$k" | sed -e 's/[.[\\*^$&/]/\\&/g')
+    text=$(printf '%s' "$text" | sed -e "s/$esc_k/$v/g")
+  done
+  printf '%s' "$text"
+}
+
+ROLE=$(replace_dict "$ROLE")
+GOAL=$(replace_dict "$GOAL")
+CONS=$(replace_dict "$CONS")
+REASON=$(replace_dict "$REASON")
+OUT=$(replace_dict "$OUT")
+
+prompt="Follow these instructions exactly.\n::r $ROLE\n::g $GOAL"
+[[ -n "$CONS" ]] && prompt+=$'\n'"::c $CONS"
+[[ -n "$REASON" ]] && prompt+=$'\n'"::s $REASON"
+[[ -n "$OUT" ]] && prompt+=$'\n'"::o $OUT"
+
+if $ESTIMATE; then
+  raw_tokens=$(printf '%s' "$prompt" | wc -w | tr -d ' ')
+  compressed_tokens=$(printf '%s %s %s %s %s' "$ROLE" "$GOAL" "$CONS" "$REASON" "$OUT" | wc -w | tr -d ' ')
+  if [ "$raw_tokens" -gt 0 ]; then
+    savings=$(( (raw_tokens - compressed_tokens) * 100 / raw_tokens ))
+  else
+    savings=0
+  fi
+  echo "raw=$raw_tokens compressed=$compressed_tokens savings=${savings}%" >&2
+  mkdir -p "$HOME/.cx/metrics"
+  project=$(basename "$(pwd)")
+  timestamp=$(date -u +"%Y-%m-%dT%H:%MZ")
+  echo "[$timestamp] raw=$raw_tokens compressed=$compressed_tokens savings=${savings}%" >> "$HOME/.cx/metrics/$project.log"
+fi
+
+echo -e "$prompt"
+
+if ! $DRY; then
+  echo "(no API call implemented)" >&2
+fi
+

--- a/cx5
+++ b/cx5
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+Usage: cx5 role=VALUE goal=VALUE [cons=VAL] [reason=VAL] [raw=VAL] [out=VAL]
+USAGE
+}
+
+ARGS=()
+for arg in "$@"; do
+  case "$arg" in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      ARGS+=("$arg")
+      ;;
+  esac
+done
+
+ROLE=""
+GOAL=""
+CONS=""
+REASON=""
+RAW=""
+OUT=""
+
+for pair in "${ARGS[@]}"; do
+  key="${pair%%=*}"
+  value="${pair#*=}"
+  case "$key" in
+    role) ROLE="$value" ;;
+    goal) GOAL="$value" ;;
+    cons|constraints) CONS="$value" ;;
+    reason|reasons) REASON="$value" ;;
+    raw|R) RAW="$value" ;;
+    out|output) OUT="$value" ;;
+    *) echo "Unknown arg: $key" >&2 ;;
+  esac
+done
+
+if [[ -z "$ROLE" || -z "$GOAL" ]]; then
+  usage
+  exit 1
+fi
+
+# Load dictionary entries from $HOME/.cx/dict and ./.cx/dict
+declare -A DICT INV
+load_dict() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+  while IFS='=' read -r k v; do
+    [[ -n "$k" ]] || continue
+    DICT["$k"]="$v"
+    INV["$v"]="$k"
+  done < "$file"
+}
+
+load_dict "$HOME/.cx/dict"
+load_dict ".cx/dict"
+
+# Sort dictionary values by length for longest-first replacements
+set +u
+if [ ${#INV[@]} -gt 0 ]; then
+  mapfile -t sorted_pairs < <(
+    for v in "${!INV[@]}"; do
+      printf '%s\t%s\n' "$v" "${INV[$v]}"
+    done | awk -F'\t' '{print length($1)"\t"$1"\t"$2}' | sort -nr | cut -f2-)
+else
+  sorted_pairs=()
+fi
+set -u
+
+replace_with_symbols() {
+  local text="$1"
+  local pair val key esc
+  for pair in "${sorted_pairs[@]}"; do
+    IFS=$'\t' read -r val key <<<"$pair"
+    esc=$(printf '%s' "$val" | sed -e 's/[.[\\*^$&/]/\\&/g')
+    text=$(printf '%s' "$text" | sed -e "s/$esc/$key/g")
+  done
+  printf '%s' "$text"
+}
+
+# Expand ^st{N} to ^stN before compression
+global_expand_st() {
+  printf '%s' "$1" | sed -E 's/\^st\{([0-9]+)\}/^st\1/g'
+}
+
+# Normalize comma spacing
+global_norm_commas() {
+  printf '%s' "$1" | sed -E 's/ *, */,/g; s/,/, /g'
+}
+
+ROLE=$(global_expand_st "$ROLE")
+GOAL=$(global_expand_st "$GOAL")
+CONS=$(global_expand_st "$CONS")
+REASON=$(global_expand_st "$REASON")
+OUT=$(global_expand_st "$OUT")
+RAW=$(global_expand_st "$RAW")
+
+ROLE=$(replace_with_symbols "$ROLE")
+GOAL=$(replace_with_symbols "$GOAL")
+CONS=$(replace_with_symbols "$CONS")
+REASON=$(replace_with_symbols "$REASON")
+OUT=$(replace_with_symbols "$OUT")
+RAW=$(replace_with_symbols "$RAW")
+
+GOAL=$(global_norm_commas "$GOAL")
+CONS=$(global_norm_commas "$CONS")
+REASON=$(global_norm_commas "$REASON")
+
+F="∫($ROLE ⊕ goal($GOAL)"
+[[ -n "$CONS" ]] && F+=" ⊕ d[$CONS]"
+[[ -n "$REASON" ]] && F+=" ⊕ Π{$REASON}"
+F+=")"
+
+printf 'CX5|v=1|Σ=|F=%s|R=%s|O=%s\n' "$F" "$RAW" "$OUT"

--- a/decompression_spec.md
+++ b/decompression_spec.md
@@ -1,0 +1,6 @@
+# CX Decompression Spec
+- Expand symbols using `~/.cx/dict` and project `.cx/dict`.
+- Convert `^stN` into "Return at most N bullet points."
+- Normalize comma spacing before expansion.
+- Fold any `R` raw terms back into goals or constraints.
+- Output concise Markdown with no preface.

--- a/developer_notes.md
+++ b/developer_notes.md
@@ -1,0 +1,54 @@
+# Developer Notes
+- Implement a symbolic prompt language (SYM-5) using :: tags: r (role), g (goal), c (constraints), s (steps), e (examples), o (output).
+- Support micro-codes such as ^ts (think step-by-step), ^mm (minimal tokens), ^ck (list assumptions), ^rg (reason then answer), ^fx (hedge facts), ^st{N} (N bullet limit), ^md (concise Markdown), ^ps (pseudocode), ^cx (compressed recap), ^qa (Q&A pairs).
+- Include domain shorthands like @sec, @ds, and @dev to compress recurring personas; allow the dictionary to extend this set.
+- Support numeric macros like `#42` to expand policy bundles or other presets via dictionary entries.
+- Provide Bash alias `cx` that expands SYM-5 prompts using a dictionary and sed replacements.
+- Provide Bash compressors/aliases `cx` (expand) and `cx5` (compress to CX5) using dictionary-based replacements.
+- `cx5` inverts dictionaries from `$HOME/.cx/dict` and `./.cx/dict`, replaces phrases with symbols longest-first, normalizes commas,
+  expands `^st{N}` to `^stN`, and emits `CX5|v=1|Σ=|F=∫(...)|R=|O=`.
+- Alias workflow: load a dictionary of personas and hints, expand `^st{N}` limits, sort keys by length for longest-first replacements, escape sed special characters, build blocks for ::r/::g/::c/::s/::e/::o via awk, and prefix "Follow these instructions exactly.".
+- Wrappers should also normalize comma spacing in constraint and reasoning lists before compression to ensure consistent tokens.
+- Provide PowerShell function `Invoke-Codex` with equivalent expansion logic (see `Invoke-Codex.ps1`).
+- PowerShell variant uses an ordered map, regex-based replacements, and a `Get-Block` helper following `$name = ${name}` style.
+- Define algorithmic compression format CX5-ALG v1: `CX5|v=1|Σ=|F=∫(... ⊕ ...)|R=|O=`.
+- Enumerate CX5-ALG operators: ∫ integrate, d[] apply delta constraints, ⊕ add, ⊗ cross/mix, ≈ similarity hint, → output, Π pipeline order, Σ summary request.
+- Design is transport-agnostic; expanded prompts can pipe into any API client.
+- Include decompression spec for ChatGPT so compressed lines can be expanded within each chat session.
+- Decompression spec should output concise Markdown with no preface, infer unknown symbols and ask at most one clarifying question, and return only the expanded instruction.
+- If `R` is present, fold raw terms into the goal or constraints during decompression.
+- The Bash `cx` wrapper accepts an optional `raw=` parameter and folds those raw terms into the goal or constraint sections before expansion.
+- Implement Bash compressor `cx5` and PowerShell `Compress-CX5` to emit CX5 strings (see `Compress-CX5.ps1`).
+- PowerShell `Compress-CX5` validates that `role` and `goal` are provided, normalizes comma spacing with `-replace`, builds the `F` string, and returns the single-line `CX5|...` output.
+- Compressors accept key=value args, normalize comma spacing in hints, build `F` via `∫(role ⊕ goal(...) ⊕ d[constraints] ⊕ Π{reason})`, and emit `CX5|v=1|Σ=|F=...|R=...|O=...`.
+- Differentiate → Integrate compression:
+  - Differentiate: extract role, goal, constraints, reasoning, and output; normalize comma spacing; convert recurring ideas to symbols; stash stray nouns in `R` and format/limits in `O`; skip `Σ` when only built-ins are present.
+  - Integrate: encode the facets as `F=∫(role ⊕ goal(...) ⊕ d[constraints] ⊕ Π{reason})` and attach any `R`/`O` residuals.
+- If a domain recurs, mint a tag (e.g., @domX) and teach it once to keep future prompts short.
+- Handle unknown symbols by inferring safely and asking at most one clarifying question.
+- Wrappers should prompt the user to define unknown symbols, auto-update the on-disk dictionary, and keep future prompts concise.
+- Wrappers auto-mint domain tags by detecting repeated plain phrases and offering `@tag` definitions so recurring concepts compress well.
+- Project dictionaries prune to the most recent 100 entries (LRU) to keep Σ minimal.
+- Maintain concise Markdown output with no extra preface.
+- Future enhancements: adaptive symbol learning that auto-mints domain tags (e.g., @wpsec, @netops).
+- Token estimator should be available via a `--estimate` CLI flag to report token counts without submitting prompts.
+- Estimator should output both raw and compressed counts with a percentage savings report.
+- Estimator should also log raw/compressed counts and percentage savings under `~/.cx/metrics` for per-project tracking.
+- Add a `--dry` flag to preview the expanded instruction without calling the API, useful for debugging.
+- Wrappers should validate that `role` and `goal` are provided; print a usage message otherwise.
+- `--estimate` implies a dry-run so token counts can be previewed without sending the prompt.
+- Provide a cross-platform install script that configures aliases, seeds a default dictionary, and drops the decompression spec.
+- Installer should be idempotent, create `~/.cx` plus a `metrics` subdirectory, and verify assets on repeated runs.
+- Installer should place the decompression spec under `~/.cx` so users can paste it into new chats.
+- When expanding shell variables, preserve style such as `$name` → `${name}`.
+- Reference end-to-end usage: `cx5 role=@dev goal='tiny http server in python' cons='^mm,^md,^st5' reason='^ts,^rg' out='code+bullets'.`
+- Token estimator should append timestamped entries to `~/.cx/metrics/<project>.log` so savings history is preserved.
+- Each metrics entry should record the timestamp, raw count, compressed count, and percentage savings for auditing.
+- The estimator should derive the `<project>` name from the current working directory when logging metrics.
+- Metrics logs should follow a readable format like `[2025-08-29T12:00Z] raw=123 compressed=45 savings=63%` for easy parsing.
+- `--estimate` may be combined with `--dry` to show token counts alongside the expanded instruction without hitting the API.
+- Installer must avoid clobbering existing dictionaries and verify required assets before overwriting.
+- Auto-minted domain tags (e.g., @domX) should be persisted to the dictionary for reuse across sessions.
+- Wrappers may auto-load a `.cx/dict` file from the current project folder to supply domain-specific symbols automatically and honor numeric macros like `#42` defined in those dictionaries.
+
+- `install.sh` seeds `~/.cx` with a starter dict, metrics folder, and decompression spec, then installs `cx` to `~/.local/bin`.

--- a/goals.md
+++ b/goals.md
@@ -1,0 +1,25 @@
+# Goals
+- Build codex wrapper application supporting SYM-5 and CX5-ALG compression.
+- Implement Bash alias `cx` and `cx5` along with PowerShell `Invoke-Codex` and `Compress-CX5` functions. *(DONE)*
+- Ensure alias replacements escape special characters and sort by key length to avoid partial overlaps.
+- Add per-project dictionaries auto-loaded by folder and support for numeric macros (e.g., #42 → policy bundles). *(DONE)*
+- Create a dry-run token estimator comparing compressed versus uncompressed prompts to preview savings before sending, exposed via a `--estimate` flag. *(DONE)*
+- Provide a `--dry` option to preview the expanded prompt without sending it to the model. *(DONE)*
+- Implement adaptive symbol learning that auto-mints domain tags like @wpsec or @netops. *(DONE)*
+- Provide an automated Codex install script that configures aliases, seeds a default dictionary, and installs the decompression spec. *(DONE)*
+- Installer should drop the decompression spec into `~/.cx` for easy reuse across chats.
+- Track token savings metrics per project. *(DONE)*
+- Implement LFU/LRU dictionary eviction for custom symbols to keep Σ minimal. *(LRU DONE)*
+- Add a clarifying-question mechanism to handle unknown symbols safely and update the dictionary automatically. *(DONE)*
+- Ensure the token estimator reports raw vs compressed counts and percentage savings without calling the API.
+- Make the install script idempotent and drop assets in a standard `~/.cx` directory.
+- Persist token-savings logs under `~/.cx/metrics` for project-level tracking.
+- Derive the metrics filename from the current directory so each project logs to its own `<project>.log`.
+- Normalize comma spacing in constraint and reasoning lists before compression for deterministic tokens. *(DONE)*
+- Allow combining `--estimate` with `--dry` to preview expanded prompts and token metrics simultaneously. *(DONE)*
+- Append timestamped token-savings entries to `~/.cx/metrics/<project>.log` for historical tracking. *(DONE)*
+- Standardize each metrics entry as `[ISO timestamp] raw=X compressed=Y savings=Z%` for easy consumption. *(DONE)*
+- Each logged entry should capture raw and compressed counts along with the percentage savings. *(DONE)*
+- Ensure the installer preserves existing dictionary entries while verifying required assets and creating a metrics subdirectory. *(DONE)*
+- Persist auto-minted domain tags to dictionaries so they can be reused across sessions. *(DONE)*
+- Teach the decompressor to fold any `R` raw terms into goal or constraint sections during expansion. *(DONE)*

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,23 @@
+param()
+
+$installDir = Join-Path $HOME '.cx'
+$binDir = Join-Path $HOME 'bin'
+
+New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $installDir 'metrics') -Force | Out-Null
+New-Item -ItemType Directory -Path $binDir -Force | Out-Null
+
+if (-not (Test-Path (Join-Path $installDir 'dict'))) {
+    Copy-Item '.cx/dict' (Join-Path $installDir 'dict')
+}
+
+if (-not (Test-Path (Join-Path $installDir 'decompression_spec.md'))) {
+    Copy-Item 'decompression_spec.md' (Join-Path $installDir 'decompression_spec.md')
+}
+
+Copy-Item 'Invoke-Codex.ps1' (Join-Path $binDir 'Invoke-Codex.ps1') -Force
+Copy-Item 'Compress-CX5.ps1' (Join-Path $binDir 'Compress-CX5.ps1') -Force
+
+Write-Output "Installed Invoke-Codex.ps1 and Compress-CX5.ps1 to $binDir"
+Write-Output "Dictionary and decompression spec ensured under $installDir"
+Write-Output "Add $binDir to your PATH and dot-source the functions in your PowerShell profile."

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INSTALL_DIR="$HOME/.cx"
+BIN_DIR="$HOME/.local/bin"
+
+mkdir -p "$INSTALL_DIR/metrics" "$BIN_DIR"
+
+# Seed dictionary if missing
+if [ ! -f "$INSTALL_DIR/dict" ]; then
+  cp .cx/dict "$INSTALL_DIR/dict"
+fi
+
+# Install decompression spec if missing
+if [ ! -f "$INSTALL_DIR/decompression_spec.md" ]; then
+  cp decompression_spec.md "$INSTALL_DIR/decompression_spec.md"
+fi
+
+# Install cx and cx5 wrappers
+cp cx "$BIN_DIR/cx"
+chmod +x "$BIN_DIR/cx"
+cp cx5 "$BIN_DIR/cx5"
+chmod +x "$BIN_DIR/cx5"
+
+echo "Installed cx to $BIN_DIR/cx"
+echo "Installed cx5 to $BIN_DIR/cx5"
+echo "Dictionary and decompression spec ensured under $INSTALL_DIR"
+echo "Make sure $BIN_DIR is in your PATH"

--- a/personal_notes.md
+++ b/personal_notes.md
@@ -1,0 +1,45 @@
+# Personal Notes
+- Maintain a small, reusable dictionary of symbols for frequent domains and reasoning hints.
+- Keep prompts concise; leverage micro-codes and tags instead of verbose instructions.
+- Expand the dictionary as new projects require custom roles or hints.
+- Practice using domain shorthands like @sec, @ds, and @dev to keep prompts tiny.
+- Leverage auto-loaded per-project dictionaries and use numeric macros like #42 for policy bundles.
+- Build a dry-run token estimator to measure savings before sending prompts.
+- Try adaptive symbol learning to auto-mint new domain codes.
+- Consider building tools for tracking token savings and managing per-project symbols.
+- Use the `--estimate` flag to preview token counts and `--dry` to inspect expanded prompts before sending.
+- Remember that `--estimate` implies `--dry` so token counts never trigger an API call.
+- Always provide both `role=` and `goal=`; the wrapper errors out otherwise.
+- Capture both raw and compressed token counts and note percentage savings.
+- Apply a Differentiate → Integrate workflow when encoding prompts.
+- Convert recurring concepts to symbols first; stash leftover nouns in `R` and output limits in `O`.
+- Fold any `R` raw terms back into the goal or constraints when decompressing prompts.
+- Use LFU/LRU strategies to keep the dictionary trim.
+ - Project dictionary automatically prunes to the most recent 100 entries to stay slim.
+- If a symbol is unfamiliar, infer meaning and ask one clarifying question at most.
+- Reuse the expander spec across chats and keep instruction blocks short.
+- Wrappers expand `^st{N}`, perform longest-first replacements, and prepend "Follow these instructions exactly.".
+- Double-check that replacements escape special characters and favor longest matches to avoid partial overlaps.
+- Auto-mint domain tags like @wpsec or @netops when patterns recur, then reuse them to keep prompts short.
+- Compare compressed vs uncompressed token counts to verify savings.
+- Follow shell variable style `$name = ${name}` when crafting examples.
+- Normalize commas in constraint and reasoning lists before compression.
+- Test the full cx5 pipeline with command: `cx5 role=@dev goal='tiny http server in python' cons='^mm,^md,^st5' reason='^ts,^rg' out='code+bullets'.`
+- Test the full cx5 pipeline and ensure dictionary phrases convert back to symbols correctly.
+- Verify the install script sets up aliases, a starter dictionary, and the decompression spec across Bash and PowerShell.
+- Ensure the installer is idempotent and writes assets to a standard `~/.cx` directory.
+- Prompt users to define unknown symbols so the dictionary stays current.
+- Log percentage savings from `--estimate` for each project.
+- Run the installer multiple times to confirm idempotency on different platforms and check that `~/.cx/metrics` is seeded.
+- Verify `--estimate` logs appear under `~/.cx/metrics` with raw/compressed counts and savings percent.
+- Ensure each metrics log is named after the current directory so project histories stay separate.
+- Log each `--estimate` run to `~/.cx/metrics/<project>.log` with a timestamp and percentage savings.
+- Keep the decompression spec stored in `~/.cx` handy to seed new chats quickly.
+- Double-check metrics logs include timestamp, raw count, compressed count, and percent savings.
+- Format each entry like `[2025-08-29T12:00Z] raw=123 compressed=45 savings=63%` so parsing is straightforward.
+- Pair `--dry` with `--estimate` when debugging to inspect expanded prompts and counts without sending.
+- After clarifying an unknown symbol, save the definition so the dictionary stays current.
+- Verify the installer skips overwriting existing dictionary entries and confirms `~/.cx/metrics` exists.
+- Keep a project-level `.cx/dict` so symbols auto-load whenever I enter the folder.
+
+- Use `install.sh` to set up `cx` and seed `~/.cx` assets before first use.


### PR DESCRIPTION
## Summary
- Introduce PowerShell `Invoke-Codex` and `Compress-CX5` scripts mirroring Bash wrappers with dictionary prompts and token estimation
- Ship `install.ps1` to deploy PowerShell scripts alongside existing Bash installer
- Document Windows usage, update goals, and log progress in Chatlog

## Testing
- `bash -n cx`
- `bash -n cx5`
- `bash -n install.sh`
- `./install.sh`
- `./cx role=@dev goal='demo' cons='^mm,^st{3}' reason='^ts' out='code' --estimate --dry`
- `pwsh ./install.ps1` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b083bd18848321ac665d078cb110ed